### PR TITLE
Call measurement unit correctly, add depth to serializer for component

### DIFF
--- a/inventory/serializers.py
+++ b/inventory/serializers.py
@@ -27,8 +27,9 @@ class ComponentSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = Component
         fields = ['url', 'name', 'sku', 'mpn', 'upc', 'storage_bin','measurement_unit', 'qty']
+        depth = 4
 
 class ComponentMeasurementUnitSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = ComponentMeasurementUnit
-        fields = ['url', 'name', 'description']
+        fields = ['url', 'unit_name', 'unit_description']


### PR DESCRIPTION
This PR adds a "depth" to the component call for the API which returns all the data nested right up to building level instead of having to chase the API URL's back.

This makes it much faster to act on the relevant data without having to do multiple calls to the API to locate a component.